### PR TITLE
Fix failing tests

### DIFF
--- a/addon/components/hold-button.js
+++ b/addon/components/hold-button.js
@@ -48,11 +48,13 @@ var HoldButtonComponent = Component.extend(positionalParams, {
 
   registerHandler() {
     this.on('mouseDown', this, this.startTimer);
-    this.on('touchStart', this, e => {
-      e.stopPropagation();
-      e.preventDefault();
-      this.startTimer();
-    });
+    this.on('touchStart', this, this.startTouchTimer);
+  },
+
+  startTouchTimer(e) {
+    e.stopPropagation();
+    e.preventDefault();
+    this.startTimer();
   },
 
   startTimer() {
@@ -60,7 +62,9 @@ var HoldButtonComponent = Component.extend(positionalParams, {
       this.set('isComplete', false);
       this.set('isHolding', true);
 
-      this.off('mouseDown');
+      this.off('mouseDown', this, this.startTimer);
+      this.off('touchStart', this, this.startTouchTimer);
+
       this.on('mouseUp', this, this.cancelTimer);
       this.on('mouseLeave', this, this.cancelTimer);
       this.on('touchEnd', this, this.cancelTimer);
@@ -75,10 +79,10 @@ var HoldButtonComponent = Component.extend(positionalParams, {
     this.set('isHolding', false);
     cancel(this.get('timer'));
     this.set('timer', null);
-    this.off('mouseUp');
-    this.off('mouseLeave');
-    this.off('touchEnd');
-    this.off('touchCancel');
+    this.off('mouseUp', this, this.cancelTimer);
+    this.off('mouseLeave', this, this.cancelTimer);
+    this.off('touchEnd', this, this.cancelTimer);
+    this.off('touchCancel', this, this.cancelTimer);
     this.registerHandler();
   },
 

--- a/tests/integration/components/hold-button-test.js
+++ b/tests/integration/components/hold-button-test.js
@@ -1,4 +1,3 @@
-import { later, next } from '@ember/runloop';
 import { Promise } from 'rsvp';
 import { registerAsyncHelper } from '@ember/test';
 import { module, test } from 'qunit';
@@ -55,7 +54,6 @@ module('Integration | Component | hold button', function(hooks) {
   });
 
   test('it calls the action', async function(assert) {
-    const done = assert.async();
     assert.expect(4);
     await render(hbs`{{hold-button delay=0 action='finished'}}`);
     let el = find('.ember-hold-button');
@@ -65,24 +63,21 @@ module('Integration | Component | hold button', function(hooks) {
       finished = true;
     };
 
-    triggerEvent(el, 'mousedown');
-    later(() => {
-      assert.ok(el.classList.contains('is-holding'), 'is-holding class added');
-      triggerEvent(el, 'mouseup');
+    await triggerEvent(el, 'mousedown');
 
-      later(() => {
-        assert.ok(
-          !el.classList.contains('is-holding'),
-          'is-holding class removed'
-        );
-        assert.ok(
-          el.classList.contains('is-complete'),
-          'is-complete class added'
-        );
-        assert.ok(finished, 'finished action called', 'finish called');
-        done();
-      });
-    });
+    assert.ok(el.classList.contains('is-holding'), 'is-holding class added');
+
+    await triggerEvent(el, 'mouseup');
+
+    assert.ok(
+      !el.classList.contains('is-holding'),
+      'is-holding class removed'
+    );
+    assert.ok(
+      el.classList.contains('is-complete'),
+      'is-complete class added'
+    );
+    assert.ok(finished, 'finished action called', 'finish called');
   });
 
   test('type reflects CSS class', async function(assert) {
@@ -101,38 +96,32 @@ module('Integration | Component | hold button', function(hooks) {
       hbs`{{hold-button "cheese" delay=0 action='finished' type='banana'}}`
     );
     let el = find('.ember-hold-button');
-    triggerEvent(el, 'mousedown');
-
-    later(() => {
-      triggerEvent(el, 'mouseup');
-    });
+    await triggerEvent(el, 'mousedown');
+    await triggerEvent(el, 'mouseup');
   });
 
   test('touch events work correctly', async function(assert) {
-    const done = assert.async();
     assert.expect(3);
+
     this.actions.finished = () => {
       assert.ok(true, 'Action triggered');
     };
 
     await render(hbs`{{hold-button delay=0 action='finished'}}`);
+
     let el = find('.ember-hold-button');
-    triggerEvent(el, 'touchstart');
+    await triggerEvent(el, 'touchstart');
 
-    next(() => {
-      assert.ok(
-        el.classList.contains('is-holding'),
-        'Class added while holding'
-      );
-      triggerEvent(el, 'touchend');
+    assert.ok(
+      el.classList.contains('is-holding'),
+      'Class added while holding'
+    );
 
-      next(() => {
-        assert.ok(
-          el.classList.contains('is-complete'),
-          'Class added when complete'
-        );
-        done();
-      });
-    });
+    await triggerEvent(el, 'touchend');
+
+    assert.ok(
+      el.classList.contains('is-complete'),
+      'Class added when complete'
+    );
   });
 });


### PR DESCRIPTION
There were two major bugs present which caused tests to break:

1. `await` UI Interactions in integration tests
```js
// await event before assertion
await triggerEvent(el, 'mouseup');
assert.ok(el.classList.contains('is-holding'), 'is-holding class added');
```

2. We must "pass at least an object, event name, and method or target and method/method name to removeListener", ie `this.off('mouseDown', this, this.startTimer);`
```js
// remove event listener
this.off('mouseDown', this, this.startTimer);
```